### PR TITLE
Fix hidden link text when anchors contain images

### DIFF
--- a/dist/liquid-dark.css
+++ b/dist/liquid-dark.css
@@ -336,6 +336,13 @@ a {
     color: var(--link-color);
     text-decoration: none;
 }
+
+#write a:has(img) {
+    background: none;
+    background-clip: border-box;
+    -webkit-background-clip: border-box;
+    color: var(--link-color);
+}
 .md-content {
     color: var(--light-text-color);
 }

--- a/dist/liquid-ink-dark.css
+++ b/dist/liquid-ink-dark.css
@@ -330,6 +330,13 @@ a {
     color: var(--link-color);
     text-decoration: none;
 }
+
+#write a:has(img) {
+    background: none;
+    background-clip: border-box;
+    -webkit-background-clip: border-box;
+    color: var(--link-color);
+}
 .md-content {
     color: var(--light-text-color);
 }

--- a/dist/liquid-ink.css
+++ b/dist/liquid-ink.css
@@ -241,6 +241,13 @@ a {
     color: var(--link-color);
     text-decoration: none;
 }
+
+#write a:has(img) {
+    background: none;
+    background-clip: border-box;
+    -webkit-background-clip: border-box;
+    color: var(--link-color);
+}
 .md-content {
     color: var(--light-text-color);
 }

--- a/dist/liquid.css
+++ b/dist/liquid.css
@@ -247,6 +247,13 @@ a {
     color: var(--link-color);
     text-decoration: none;
 }
+
+#write a:has(img) {
+    background: none;
+    background-clip: border-box;
+    -webkit-background-clip: border-box;
+    color: var(--link-color);
+}
 .md-content {
     color: var(--light-text-color);
 }

--- a/src/liquid/main.css
+++ b/src/liquid/main.css
@@ -153,6 +153,13 @@ a {
     text-decoration: none;
 }
 
+#write a:has(img) {
+    background: none;
+    background-clip: border-box;
+    -webkit-background-clip: border-box;
+    color: var(--link-color);
+}
+
 .md-content {
     color: var(--light-text-color);
 }


### PR DESCRIPTION
### Motivation
- Users reported link text disappearing when an `<img>` is placed inside an `<a>`, particularly during image-link editing, due to gradient link styling using `color: transparent` with `background-clip: text` which hides adjacent text in mixed-content anchors.

### Description
- Added a targeted CSS rule `#write a:has(img)` that disables the gradient text clipping and restores `color: var(--link-color)` for anchors that contain images.
- Applied the change in the source stylesheet `src/liquid/main.css` and mirrored it to distributed bundles `dist/liquid.css`, `dist/liquid-dark.css`, `dist/liquid-ink.css`, and `dist/liquid-ink-dark.css` to keep shipped CSS consistent.

### Testing
- Confirmed the new selector exists in all modified files using `rg -n '#write a:has(img)'` (passed).
- Inspected the modified CSS regions with `nl`/`sed` to verify the inserted rule content and placement (passed).
- Attempted a Python network fetch using `requests` which failed because the environment lacks the `requests` module (failed), and performed a `curl`-based search which completed successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699009bd88908329b73d9d4b4266ad2d)