### PR TITLE
Fix PDF export text visibility for Liquid theme in SumatraPDF

### DIFF
--- a/src/liquid/main.css
+++ b/src/liquid/main.css
@@ -17,37 +17,6 @@
         max-width: 100%;
     }
 
-    /*
-     * PDF readers like SumatraPDF may not render text clipped to a gradient
-     * background, resulting in invisible headings/links when color is transparent.
-     * Fall back to solid colors for print/PDF output.
-     */
-    #write h1,
-    #write h2,
-    #write h3,
-    #write h4,
-    #write h5,
-    #write h6,
-    #write a {
-        background: none;
-        -webkit-background-clip: border-box;
-        background-clip: border-box;
-        color: inherit;
-    }
-
-    #write h1,
-    #write h2,
-    #write h3,
-    #write h4,
-    #write h5,
-    #write h6 {
-        color: var(--title-color);
-    }
-
-    #write a {
-        color: var(--link-color);
-    }
-
     @page {
         size: A4; /* PDF A4 */
         margin-left: 0;
@@ -182,6 +151,40 @@ a {
     border-bottom: 1px solid var(--link-color);
     color: var(--link-color);
     text-decoration: none;
+}
+
+/* Print-only fallback must come after gradient text rules with the same specificity. */
+@media print {
+    /*
+     * PDF readers like SumatraPDF may not render text clipped to a gradient
+     * background, resulting in invisible headings/links when color is transparent.
+     * Fall back to solid colors for print/PDF output.
+     */
+    #write h1,
+    #write h2,
+    #write h3,
+    #write h4,
+    #write h5,
+    #write h6,
+    #write a {
+        background: none;
+        -webkit-background-clip: border-box;
+        background-clip: border-box;
+        color: inherit;
+    }
+
+    #write h1,
+    #write h2,
+    #write h3,
+    #write h4,
+    #write h5,
+    #write h6 {
+        color: var(--title-color);
+    }
+
+    #write a {
+        color: var(--link-color);
+    }
 }
 
 .md-content {

--- a/src/liquid/main.css
+++ b/src/liquid/main.css
@@ -17,6 +17,37 @@
         max-width: 100%;
     }
 
+    /*
+     * PDF readers like SumatraPDF may not render text clipped to a gradient
+     * background, resulting in invisible headings/links when color is transparent.
+     * Fall back to solid colors for print/PDF output.
+     */
+    #write h1,
+    #write h2,
+    #write h3,
+    #write h4,
+    #write h5,
+    #write h6,
+    #write a {
+        background: none;
+        -webkit-background-clip: border-box;
+        background-clip: border-box;
+        color: inherit;
+    }
+
+    #write h1,
+    #write h2,
+    #write h3,
+    #write h4,
+    #write h5,
+    #write h6 {
+        color: var(--title-color);
+    }
+
+    #write a {
+        color: var(--link-color);
+    }
+
     @page {
         size: A4; /* PDF A4 */
         margin-left: 0;


### PR DESCRIPTION
### Motivation
- Some PDF viewers (notably SumatraPDF) fail to render gradient-clipped text produced by `background-clip: text` with `color: transparent`, which can make headings and links invisible in exported PDFs.

### Description
- Added print-only fallbacks inside `@media print` in `src/liquid/main.css` to avoid relying on gradient text clipping for PDF/print output.
- For `#write h1…h6` and `#write a` the stylesheet disables the gradient clipping (`background: none`) and sets `background-clip: border-box` with `color: inherit` to ensure text is rendered.
- Explicitly restores solid print colors so headings use `var(--title-color)` and links use `var(--link-color)` while leaving on-screen/theme rendering unchanged.

### Testing
- Ran a symbol search (`rg`) to locate heading/gradient selectors and confirm the change targets the correct rules, which succeeded.
- Inspected the patch with `git diff -- src/liquid/main.css` to verify the inserted print rules, which succeeded.
- Ran `git diff --check` to validate whitespace/format issues and it reported no problems.
- There is no automated test suite configured for CSS-only changes in this repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900f085c688329ac3d5387f69002bd)