### PR TITLE
Restore H1 headings in TOC

### DIFF
--- a/src/liquid/main.css
+++ b/src/liquid/main.css
@@ -343,10 +343,6 @@ img[alt|="shadow"] {
     font-size: 1rem;
 }
 
-.md-toc-h1 {
-    display: none;
-}
-
 #write .md-toc-h2 .md-toc-inner {
     font-size: 1.2rem;
 }


### PR DESCRIPTION
### Motivation
- Level-1 headings were being hidden from the generated table of contents due to a CSS rule, and the change restores H1 entries so top-level headings appear in the TOC again.

### Description
- Removed the CSS rule that hid `.md-toc-h1` from `src/liquid/main.css` (deleted the `.md-toc-h1 { display: none; }` block) so H1 entries are shown in the TOC.

### Testing
- Verified the change and file diff via `git diff`/`git show --stat` and inspected the updated file contents with `nl -ba src/liquid/main.css | sed -n '334,374p'`, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699024be7a248329b40f91f3f3898399)