### PR TITLE
docs: rewrite README and docs to reflect source-first layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,80 +28,64 @@ typora-copy-images-to: ../../media/theme/Liquid
 
 [English](https://github.com/ruiyangzhou01/Liquid/blob/main/README.md) • [中文](https://github.com/ruiyangzhou01/Liquid/blob/main/README_zh.md) • [Deutsch](https://github.com/ruiyangzhou01/Liquid/blob/main/README_de.md) • [Español](https://github.com/ruiyangzhou01/Liquid/blob/main/README_es.md) • [Français](https://github.com/ruiyangzhou01/Liquid/blob/main/README_fr.md) • [日本語](https://github.com/ruiyangzhou01/Liquid/blob/main/README_ja.md)
 
-Liquid is a Typora theme inspired by [Microsoft Fluent Design](https://www.microsoft.com/design/fluent/#/) and the [Purple Theme](https://github.com/hliu202/typora-purple-theme). It delivers a Windows 11-style reading and writing experience with gradients, mica-like surfaces, rounded rectangles, and bundled fonts. The theme ships four variants built from modular CSS.
+Liquid is a Typora theme inspired by [Microsoft Fluent Design](https://www.microsoft.com/design/fluent/#/) and the [Purple Theme](https://github.com/hliu202/typora-purple-theme). The current repository ships source-ready theme files under `src/` (no separate `dist/` build output).
+
+## Current status
+
+- Maintained theme with four variants: `liquid`, `liquid-dark`, `liquid-ink`, `liquid-ink-dark`
+- Source CSS and bundled fonts are versioned directly in this repository
+- Documentation and translations are aligned with the current source layout
 
 ## Features
 
-- Fluent Design styling with gradients, mica, rounded rectangles, and colorful indicators
-- Four variants: Light, Dark, Ink, and Ink Dark
-- Customized CodeMirror styles for code blocks
-- Bundled serif, handwriting, and monospace fonts
+- Fluent-style visuals: gradients, rounded corners, accent indicators, and mica-inspired surfaces
+- Light / Dark / Ink / Ink Dark variants
+- Customized CodeMirror styling for code blocks
+- Bundled fonts for serif text, monospaced code, and handwriting-like Ink modes
 
-## Compatibility
+## Repository layout
 
-- Windows 10 and Windows 11
-- Typora desktop app
-- Language coverage: English and Chinese (Source Han Serif CN). Ink modes also use Ink Free and FZSJ-SGLDXMHJW for handwriting.
-
-## Screenshots
-
-Liquid Theme aims to provide a modern Windows 11 visual experience in Typora. It uses UI elements such as gradients, mica material, and rounded rectangles. The theme supports English and Chinese, and it provides Light Mode, Dark Mode, Ink Mode, and Ink Dark Mode.
-
-![preview](./media/theme/liquid/preview.png)
-
-### Light Mode
-
-![light-preview1](/media/theme/liquid/light-preview1.png)
-
-![light-preview2](/media/theme/liquid/light-preview2.png)
-
-![light-preview3](/media/theme/liquid/light-preview3.png)
-
-### Dark Mode
-
-![dark-preview1](/media/theme/liquid/dark-preview1.png)
-
-![dark-preview2](/media/theme/liquid/dark-preview2.png)
-
-![dark-preview3](/media/theme/liquid/dark-preview3.png)
-
-### Ink Mode & Ink Dark Mode
-
-If you use a 2-in-1 PC such as Microsoft Surface for study or writing, or you simply prefer handwritten fonts, Ink Mode provides a handwriting-style reading and writing experience in Typora.
-
-![ink-preview1](/media/theme/liquid/ink-preview1.png)
-
-![ink-preview2](/media/theme/liquid/ink-preview2.png)
-
-![ink-preview3](/media/theme/liquid/ink-preview3.png)
+```text
+src/
+  liquid.css
+  liquid-dark.css
+  liquid-ink.css
+  liquid-ink-dark.css
+  liquid/
+    *.css
+    *.ttf
+    *.woff2
+Demo.md
+README*.md
+doc/Document*.md
+media/
+assets/
+```
 
 ## Installation
 
-1. Download `liquid.zip` from the [Releases](https://github.com/ruiyangzhou01/Liquid/releases) page.
-2. Open Typora settings. In **Preferences**, select **Appearance**, then click **Open Theme Folder**.
-3. Unzip and copy `liquid.css`, `liquid-dark.css`, `liquid-ink.css`, `liquid-ink-dark.css`, and the `liquid/` font folder into the theme folder.
-4. Restart Typora.
-5. Select the Liquid theme from the **Themes** menu in Typora.
-6. Open `Demo.md` from this repository (or the source code archive) to preview the local rendering.
-
-### Ink mode fonts
-
-Liquid bundles the Ink fonts and loads them via `@font-face`, so you usually do not need to install them system-wide. On case-sensitive file systems, make sure the font filenames in `liquid/` match the CSS references (`inkfree.ttf` and `FZSJ-SGLDXMHJW.ttf`); rename the files or update the CSS if needed. `FZSJ-SGLDXMHJW` renders Chinese characters in Ink modes, and `Inkfree` provides the handwriting font for Latin text.
-
-## Build from source
-
-The build scripts are written for Windows paths.
-
-1. Install Python 3.
-2. Run `cd src/Deploy`.
-3. Run `python CombineCSS.py` to combine `src/liquid*.css` into `dist/*.css`.
-4. (Optional) Run `cd ../deploy` and `python CompressZip.py` to package `dist` as `liquid.zip`.
+1. Download `liquid.zip` from [Releases](https://github.com/ruiyangzhou01/Liquid/releases) or clone this repository.
+2. Open Typora → **Preferences** → **Appearance** → **Open Theme Folder**.
+3. Copy these files into the Typora theme folder:
+   - `src/liquid.css`
+   - `src/liquid-dark.css`
+   - `src/liquid-ink.css`
+   - `src/liquid-ink-dark.css`
+   - `src/liquid/` (entire folder)
+4. Restart Typora and select a Liquid variant from **Themes**.
+5. Open `Demo.md` to preview the theme.
 
 ## Customization
 
-- Add custom CSS via Typora (recommended): <https://support.typora.io/Add-Custom-CSS/>.
-- Edit the compiled files in the theme folder (`dist/*.css` in this repository).
-- For deeper changes, edit the modules in `src/liquid/` and rebuild. See the documentation below.
+- Quick tweaks: edit installed `liquid*.css` files directly in your Typora theme folder.
+- Deep customization: edit module files in `src/liquid/` (`main.css`, `color-*.css`, `font*.css`, `CodeMirror*.css`, `custom-*.css`).
+- Add your own override stylesheet using Typora custom CSS: <https://support.typora.io/Add-Custom-CSS/>.
+
+## Troubleshooting
+
+- **Theme not visible in Typora**: confirm all four `liquid*.css` files are copied into the theme folder root.
+- **Fonts or Ink style missing**: confirm the `liquid/` folder is copied next to the CSS files.
+- **Glyph issues on case-sensitive systems**: verify filename case matches CSS references (for example `Inkfree.ttf` and `FZSJ-SGLDXMHJW.TTF`).
 
 ## Documentation
 

--- a/README_de.md
+++ b/README_de.md
@@ -28,80 +28,64 @@ typora-copy-images-to: ../../media/theme/Liquid
 
 [English](https://github.com/ruiyangzhou01/Liquid/blob/main/README.md) • [中文](https://github.com/ruiyangzhou01/Liquid/blob/main/README_zh.md) • [Deutsch](https://github.com/ruiyangzhou01/Liquid/blob/main/README_de.md) • [Español](https://github.com/ruiyangzhou01/Liquid/blob/main/README_es.md) • [Français](https://github.com/ruiyangzhou01/Liquid/blob/main/README_fr.md) • [日本語](https://github.com/ruiyangzhou01/Liquid/blob/main/README_ja.md)
 
-Liquid ist ein Typora-Theme, inspiriert von [Microsoft Fluent Design](https://www.microsoft.com/design/fluent/#/) und dem [Purple Theme](https://github.com/hliu202/typora-purple-theme). Es liefert ein Windows-11-ähnliches Lese- und Schreiberlebnis mit Farbverläufen, Mica-Flächen, abgerundeten Rechtecken und eingebetteten Schriftarten. Das Theme bietet vier Varianten auf Basis modularer CSS-Dateien.
+Liquid ist ein Typora-Theme, inspiriert von [Microsoft Fluent Design](https://www.microsoft.com/design/fluent/#/) und dem [Purple Theme](https://github.com/hliu202/typora-purple-theme). Dieses Repository enthält direkt nutzbare Theme-Dateien unter `src/` (kein separates `dist/`).
+
+## Aktueller Stand
+
+- Aktiv gepflegt, mit vier Varianten: `liquid`, `liquid-dark`, `liquid-ink`, `liquid-ink-dark`
+- Quell-CSS und Schriften liegen direkt im Repository
+- Dokumentation und Übersetzungen entsprechen der aktuellen Struktur
 
 ## Funktionen
 
-- Fluent-Design-Stil mit Farbverläufen, Mica, abgerundeten Rechtecken und farbigen Indikatoren
-- Vier Varianten: Light, Dark, Ink und Ink Dark
+- Fluent-ähnliches Design mit Verläufen, runden Ecken und Akzentflächen
+- Light / Dark / Ink / Ink Dark
 - Angepasste CodeMirror-Stile für Codeblöcke
-- Mitgelieferte Serif-, Handschrift- und Monospace-Schriften
+- Mitgelieferte Serif-, Monospace- und Ink-Schriften
 
-## Kompatibilität
+## Repository-Struktur
 
-- Windows 10 und Windows 11
-- Typora-Desktop-App
-- Sprachunterstützung: Englisch und Chinesisch (Source Han Serif CN). Ink-Modi verwenden zusätzlich Ink Free und FZSJ-SGLDXMHJW als Handschrift.
-
-## Screenshots
-
-Liquid Theme zielt darauf ab, Typora unter Windows 11 eine moderne Optik zu geben. Es verwendet UI-Elemente wie Farbverläufe, Mica-Material und abgerundete Rechtecke. Das Theme unterstützt Englisch und Chinesisch und bietet Light Mode, Dark Mode, Ink Mode und Ink Dark Mode.
-
-![preview](/media/theme/liquid/preview.png)
-
-### Light Mode
-
-![light-preview1](/media/theme/liquid/light-preview1.png)
-
-![light-preview2](/media/theme/liquid/light-preview2.png)
-
-![light-preview3](/media/theme/liquid/light-preview3.png)
-
-### Dark Mode
-
-![dark-preview1](/media/theme/liquid/dark-preview1.png)
-
-![dark-preview2](/media/theme/liquid/dark-preview2.png)
-
-![dark-preview3](/media/theme/liquid/dark-preview3.png)
-
-### Ink Mode & Ink Dark Mode
-
-Wenn du einen 2-in-1-PC wie Microsoft Surface zum Lernen oder Schreiben nutzt oder einfach handschriftliche Fonts bevorzugst, bietet Ink Mode in Typora ein handschriftliches Lese- und Schreiberlebnis.
-
-![ink-preview1](/media/theme/liquid/ink-preview1.png)
-
-![ink-preview2](/media/theme/liquid/ink-preview2.png)
-
-![ink-preview3](/media/theme/liquid/ink-preview3.png)
+```text
+src/
+  liquid.css
+  liquid-dark.css
+  liquid-ink.css
+  liquid-ink-dark.css
+  liquid/
+    *.css
+    *.ttf
+    *.woff2
+Demo.md
+README*.md
+doc/Document*.md
+media/
+assets/
+```
 
 ## Installation
 
-1. Lade `liquid.zip` von der Seite [Releases](https://github.com/ruiyangzhou01/Liquid/releases) herunter.
-2. Öffne in Typora **Preferences** → **Appearance** → **Open Theme Folder**.
-3. Entpacke und kopiere `liquid.css`, `liquid-dark.css`, `liquid-ink.css`, `liquid-ink-dark.css` sowie den Schriftordner `liquid/` in den Theme-Ordner.
-4. Starte Typora neu.
-5. Wähle das Liquid-Theme im **Themes**-Menü aus.
-6. Öffne `Demo.md` aus diesem Repository (oder dem Quellcode-Archiv), um die Darstellung zu prüfen.
-
-### Ink-Mode-Schriften
-
-Liquid bringt die Ink-Schriften mit und lädt sie über `@font-face`, daher ist eine systemweite Installation meist nicht nötig. Auf dateisensitiven Systemen müssen die Dateinamen im Ordner `liquid/` den CSS-Referenzen entsprechen (`inkfree.ttf` und `FZSJ-SGLDXMHJW.ttf`); benenne die Dateien um oder passe das CSS an, falls nötig. `FZSJ-SGLDXMHJW` rendert chinesische Zeichen im Ink-Modus, `Inkfree` liefert die Handschrift für lateinische Zeichen.
-
-## Aus dem Quellcode bauen
-
-Die Build-Skripte verwenden Windows-Pfade.
-
-1. Python 3 installieren.
-2. `cd src/Deploy` ausführen.
-3. `python CombineCSS.py` ausführen, um `src/liquid*.css` nach `dist/*.css` zu kombinieren.
-4. (Optional) `cd ../deploy` und `python CompressZip.py` ausführen, um `dist` als `liquid.zip` zu packen.
+1. `liquid.zip` von [Releases](https://github.com/ruiyangzhou01/Liquid/releases) laden oder Repository klonen.
+2. In Typora: **Preferences** → **Appearance** → **Open Theme Folder**.
+3. In den Theme-Ordner kopieren:
+   - `src/liquid.css`
+   - `src/liquid-dark.css`
+   - `src/liquid-ink.css`
+   - `src/liquid-ink-dark.css`
+   - `src/liquid/` (kompletter Ordner)
+4. Typora neu starten und ein Liquid-Theme auswählen.
+5. `Demo.md` zur Vorschau öffnen.
 
 ## Anpassung
 
-- Benutzerdefiniertes CSS in Typora hinzufügen (empfohlen): <https://support.typora.io/Add-Custom-CSS/>.
-- Die kompilierten Dateien im Theme-Ordner bearbeiten (`dist/*.css` in diesem Repository).
-- Für tiefergehende Änderungen die Module in `src/liquid/` anpassen und neu bauen. Siehe die Dokumentation unten.
+- Schnell anpassen: installierte `liquid*.css` direkt bearbeiten.
+- Tiefer anpassen: Module unter `src/liquid/` bearbeiten (`main.css`, `color-*.css`, `font*.css`, `CodeMirror*.css`, `custom-*.css`).
+- Eigene Overrides über Typora Custom CSS: <https://support.typora.io/Add-Custom-CSS/>.
+
+## Fehlerbehebung
+
+- **Theme erscheint nicht**: prüfen, ob alle vier `liquid*.css` im Theme-Ordner liegen.
+- **Ink/Schrift fehlt**: prüfen, ob `liquid/` neben den CSS-Dateien liegt.
+- **Dateisensitive Systeme**: Dateinamen exakt wie in CSS referenziert verwenden (`Inkfree.ttf`, `FZSJ-SGLDXMHJW.TTF`).
 
 ## Dokumentation
 

--- a/README_es.md
+++ b/README_es.md
@@ -28,80 +28,64 @@ typora-copy-images-to: ../../media/theme/Liquid
 
 [English](https://github.com/ruiyangzhou01/Liquid/blob/main/README.md) • [中文](https://github.com/ruiyangzhou01/Liquid/blob/main/README_zh.md) • [Deutsch](https://github.com/ruiyangzhou01/Liquid/blob/main/README_de.md) • [Español](https://github.com/ruiyangzhou01/Liquid/blob/main/README_es.md) • [Français](https://github.com/ruiyangzhou01/Liquid/blob/main/README_fr.md) • [日本語](https://github.com/ruiyangzhou01/Liquid/blob/main/README_ja.md)
 
-Liquid es un tema de Typora inspirado en [Microsoft Fluent Design](https://www.microsoft.com/design/fluent/#/) y en [Purple Theme](https://github.com/hliu202/typora-purple-theme). Ofrece una experiencia de lectura y escritura con estilo Windows 11 mediante degradados, superficies tipo mica, rectángulos redondeados y fuentes integradas. El tema incluye cuatro variantes construidas con CSS modular.
+Liquid es un tema de Typora inspirado en [Microsoft Fluent Design](https://www.microsoft.com/design/fluent/#/) y [Purple Theme](https://github.com/hliu202/typora-purple-theme). El repositorio actual incluye archivos listos para usar en `src/` (sin salida `dist/` separada).
+
+## Estado actual
+
+- Proyecto mantenido con cuatro variantes: `liquid`, `liquid-dark`, `liquid-ink`, `liquid-ink-dark`
+- CSS fuente y fuentes tipográficas incluidos directamente en el repositorio
+- Documentación y traducciones adaptadas al estado actual
 
 ## Características
 
-- Estilo Fluent Design con degradados, mica, rectángulos redondeados e indicadores coloridos
-- Cuatro variantes: Light, Dark, Ink e Ink Dark
-- Estilos personalizados de CodeMirror para bloques de código
-- Fuentes serif, manuscritas y monoespaciadas integradas
+- Estilo Fluent: degradados, esquinas redondeadas y acentos visuales
+- Variantes Light / Dark / Ink / Ink Dark
+- Estilos de CodeMirror personalizados para bloques de código
+- Fuentes incluidas para texto serif, código monoespaciado y estilo manuscrito Ink
 
-## Compatibilidad
+## Estructura del repositorio
 
-- Windows 10 y Windows 11
-- Aplicación de escritorio de Typora
-- Cobertura de idiomas: inglés y chino (Source Han Serif CN). Los modos Ink también usan Ink Free y FZSJ-SGLDXMHJW como letra manuscrita.
-
-## Capturas de pantalla
-
-Liquid Theme busca ofrecer una experiencia visual moderna de Windows 11 en Typora. Usa elementos de interfaz como degradados, material tipo mica y rectángulos redondeados. El tema admite inglés y chino, y proporciona Light Mode, Dark Mode, Ink Mode e Ink Dark Mode.
-
-![preview](/media/theme/liquid/preview.png)
-
-### Light Mode
-
-![light-preview1](/media/theme/liquid/light-preview1.png)
-
-![light-preview2](/media/theme/liquid/light-preview2.png)
-
-![light-preview3](/media/theme/liquid/light-preview3.png)
-
-### Dark Mode
-
-![dark-preview1](/media/theme/liquid/dark-preview1.png)
-
-![dark-preview2](/media/theme/liquid/dark-preview2.png)
-
-![dark-preview3](/media/theme/liquid/dark-preview3.png)
-
-### Ink Mode & Ink Dark Mode
-
-Si usas un PC 2 en 1 como Microsoft Surface para estudiar o escribir, o simplemente prefieres fuentes manuscritas, Ink Mode ofrece una experiencia de lectura y escritura con estilo manuscrito en Typora.
-
-![ink-preview1](/media/theme/liquid/ink-preview1.png)
-
-![ink-preview2](/media/theme/liquid/ink-preview2.png)
-
-![ink-preview3](/media/theme/liquid/ink-preview3.png)
+```text
+src/
+  liquid.css
+  liquid-dark.css
+  liquid-ink.css
+  liquid-ink-dark.css
+  liquid/
+    *.css
+    *.ttf
+    *.woff2
+Demo.md
+README*.md
+doc/Document*.md
+media/
+assets/
+```
 
 ## Instalación
 
-1. Descarga `liquid.zip` desde la página de [Releases](https://github.com/ruiyangzhou01/Liquid/releases).
-2. En Typora, abre **Preferences** → **Appearance** → **Open Theme Folder**.
-3. Descomprime y copia `liquid.css`, `liquid-dark.css`, `liquid-ink.css`, `liquid-ink-dark.css` y la carpeta de fuentes `liquid/` en la carpeta del tema.
-4. Reinicia Typora.
-5. Selecciona el tema Liquid en el menú **Themes**.
-6. Abre `Demo.md` de este repositorio (o del archivo del código fuente) para previsualizar el resultado.
-
-### Fuentes del modo Ink
-
-Liquid incluye las fuentes Ink y las carga mediante `@font-face`, por lo que normalmente no es necesario instalarlas en el sistema. En sistemas sensibles a mayúsculas, asegúrate de que los nombres de archivo en `liquid/` coincidan con lo que espera el CSS (`inkfree.ttf` y `FZSJ-SGLDXMHJW.ttf`); renombra los archivos o ajusta el CSS si es necesario. `FZSJ-SGLDXMHJW` renderiza caracteres chinos en los modos Ink y `Inkfree` aporta la letra manuscrita para texto latino.
-
-## Compilar desde el código fuente
-
-Los scripts de compilación usan rutas de Windows.
-
-1. Instala Python 3.
-2. Ejecuta `cd src/Deploy`.
-3. Ejecuta `python CombineCSS.py` para combinar `src/liquid*.css` en `dist/*.css`.
-4. (Opcional) Ejecuta `cd ../deploy` y `python CompressZip.py` para empaquetar `dist` como `liquid.zip`.
+1. Descarga `liquid.zip` desde [Releases](https://github.com/ruiyangzhou01/Liquid/releases) o clona este repositorio.
+2. En Typora: **Preferences** → **Appearance** → **Open Theme Folder**.
+3. Copia al directorio de temas:
+   - `src/liquid.css`
+   - `src/liquid-dark.css`
+   - `src/liquid-ink.css`
+   - `src/liquid-ink-dark.css`
+   - `src/liquid/` (carpeta completa)
+4. Reinicia Typora y selecciona una variante Liquid.
+5. Abre `Demo.md` para previsualizar.
 
 ## Personalización
 
-- Añade CSS personalizado en Typora (recomendado): <https://support.typora.io/Add-Custom-CSS/>.
-- Edita los archivos compilados en la carpeta del tema (`dist/*.css` en este repositorio).
-- Para cambios más profundos, edita los módulos en `src/liquid/` y vuelve a compilar. Consulta la documentación abajo.
+- Cambios rápidos: edita `liquid*.css` directamente en la carpeta de temas.
+- Cambios profundos: edita módulos de `src/liquid/` (`main.css`, `color-*.css`, `font*.css`, `CodeMirror*.css`, `custom-*.css`).
+- Overrides propios con CSS personalizado de Typora: <https://support.typora.io/Add-Custom-CSS/>.
+
+## Solución de problemas
+
+- **El tema no aparece**: confirma que los cuatro `liquid*.css` están en la raíz de la carpeta de temas.
+- **Faltan fuentes o estilo Ink**: confirma que `liquid/` está junto a los CSS.
+- **Sistemas sensibles a mayúsculas**: usa nombres exactos según CSS (`Inkfree.ttf`, `FZSJ-SGLDXMHJW.TTF`).
 
 ## Documentación
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -28,80 +28,64 @@ typora-copy-images-to: ../../media/theme/Liquid
 
 [English](https://github.com/ruiyangzhou01/Liquid/blob/main/README.md) • [中文](https://github.com/ruiyangzhou01/Liquid/blob/main/README_zh.md) • [Deutsch](https://github.com/ruiyangzhou01/Liquid/blob/main/README_de.md) • [Español](https://github.com/ruiyangzhou01/Liquid/blob/main/README_es.md) • [Français](https://github.com/ruiyangzhou01/Liquid/blob/main/README_fr.md) • [日本語](https://github.com/ruiyangzhou01/Liquid/blob/main/README_ja.md)
 
-Liquid est un thème Typora inspiré par [Microsoft Fluent Design](https://www.microsoft.com/design/fluent/#/) et le [Purple Theme](https://github.com/hliu202/typora-purple-theme). Il offre une expérience de lecture et d’écriture de style Windows 11 grâce aux dégradés, aux surfaces de type mica, aux rectangles arrondis et aux polices intégrées. Le thème propose quatre variantes basées sur du CSS modulaire.
+Liquid est un thème Typora inspiré de [Microsoft Fluent Design](https://www.microsoft.com/design/fluent/#/) et de [Purple Theme](https://github.com/hliu202/typora-purple-theme). Le dépôt actuel fournit directement les fichiers du thème sous `src/` (pas de pipeline `dist/` séparé).
+
+## État actuel
+
+- Thème maintenu avec quatre variantes : `liquid`, `liquid-dark`, `liquid-ink`, `liquid-ink-dark`
+- CSS source et polices inclus directement dans le dépôt
+- Documentation et traductions alignées avec la structure actuelle
 
 ## Fonctionnalités
 
-- Style Fluent Design avec dégradés, mica, rectangles arrondis et indicateurs colorés
-- Quatre variantes : Light, Dark, Ink et Ink Dark
-- Styles CodeMirror personnalisés pour les blocs de code
-- Polices serif, manuscrites et monospace intégrées
+- Style Fluent : dégradés, coins arrondis et accents visuels
+- Variantes Light / Dark / Ink / Ink Dark
+- Styles CodeMirror personnalisés
+- Polices incluses pour texte sérif, code monospace et mode Ink manuscrit
 
-## Compatibilité
+## Structure du dépôt
 
-- Windows 10 et Windows 11
-- Application de bureau Typora
-- Couverture linguistique : anglais et chinois (Source Han Serif CN). Les modes Ink utilisent également Ink Free et FZSJ-SGLDXMHJW pour l’écriture manuscrite.
-
-## Captures d’écran
-
-Liquid Theme vise à offrir une expérience visuelle moderne de Windows 11 dans Typora. Il utilise des éléments d’interface comme les dégradés, la matière mica et les rectangles arrondis. Le thème prend en charge l’anglais et le chinois et propose Light Mode, Dark Mode, Ink Mode et Ink Dark Mode.
-
-![preview](/media/theme/liquid/preview.png)
-
-### Light Mode
-
-![light-preview1](/media/theme/liquid/light-preview1.png)
-
-![light-preview2](/media/theme/liquid/light-preview2.png)
-
-![light-preview3](/media/theme/liquid/light-preview3.png)
-
-### Dark Mode
-
-![dark-preview1](/media/theme/liquid/dark-preview1.png)
-
-![dark-preview2](/media/theme/liquid/dark-preview2.png)
-
-![dark-preview3](/media/theme/liquid/dark-preview3.png)
-
-### Ink Mode & Ink Dark Mode
-
-Si vous utilisez un PC 2-en-1 comme Microsoft Surface pour étudier ou écrire, ou si vous préférez simplement les polices manuscrites, Ink Mode offre une expérience de lecture et d’écriture manuscrite dans Typora.
-
-![ink-preview1](/media/theme/liquid/ink-preview1.png)
-
-![ink-preview2](/media/theme/liquid/ink-preview2.png)
-
-![ink-preview3](/media/theme/liquid/ink-preview3.png)
+```text
+src/
+  liquid.css
+  liquid-dark.css
+  liquid-ink.css
+  liquid-ink-dark.css
+  liquid/
+    *.css
+    *.ttf
+    *.woff2
+Demo.md
+README*.md
+doc/Document*.md
+media/
+assets/
+```
 
 ## Installation
 
-1. Téléchargez `liquid.zip` depuis la page [Releases](https://github.com/ruiyangzhou01/Liquid/releases).
-2. Dans Typora, ouvrez **Preferences** → **Appearance** → **Open Theme Folder**.
-3. Décompressez et copiez `liquid.css`, `liquid-dark.css`, `liquid-ink.css`, `liquid-ink-dark.css` ainsi que le dossier de polices `liquid/` dans le dossier du thème.
-4. Redémarrez Typora.
-5. Sélectionnez le thème Liquid dans le menu **Themes**.
-6. Ouvrez `Demo.md` depuis ce dépôt (ou l’archive du code source) pour prévisualiser le rendu.
-
-### Polices du mode Ink
-
-Liquid inclut les polices Ink et les charge via `@font-face`, donc l’installation système n’est généralement pas nécessaire. Sur les systèmes sensibles à la casse, assurez-vous que les noms de fichiers du dossier `liquid/` correspondent aux références CSS (`inkfree.ttf` et `FZSJ-SGLDXMHJW.ttf`) ; renommez les fichiers ou modifiez le CSS si besoin. `FZSJ-SGLDXMHJW` affiche les caractères chinois en mode Ink et `Inkfree` fournit la police manuscrite pour le texte latin.
-
-## Construire depuis la source
-
-Les scripts de build utilisent des chemins Windows.
-
-1. Installez Python 3.
-2. Exécutez `cd src/Deploy`.
-3. Exécutez `python CombineCSS.py` pour combiner `src/liquid*.css` dans `dist/*.css`.
-4. (Optionnel) Exécutez `cd ../deploy` et `python CompressZip.py` pour empaqueter `dist` en `liquid.zip`.
+1. Téléchargez `liquid.zip` depuis [Releases](https://github.com/ruiyangzhou01/Liquid/releases) ou clonez ce dépôt.
+2. Dans Typora : **Preferences** → **Appearance** → **Open Theme Folder**.
+3. Copiez dans le dossier de thèmes :
+   - `src/liquid.css`
+   - `src/liquid-dark.css`
+   - `src/liquid-ink.css`
+   - `src/liquid-ink-dark.css`
+   - `src/liquid/` (dossier complet)
+4. Redémarrez Typora puis choisissez une variante Liquid.
+5. Ouvrez `Demo.md` pour vérifier le rendu.
 
 ## Personnalisation
 
-- Ajoutez du CSS personnalisé dans Typora (recommandé) : <https://support.typora.io/Add-Custom-CSS/>.
-- Modifiez les fichiers compilés dans le dossier du thème (`dist/*.css` dans ce dépôt).
-- Pour des changements plus profonds, modifiez les modules dans `src/liquid/` et reconstruisez. Consultez la documentation ci-dessous.
+- Modifications rapides : éditez directement `liquid*.css` dans le dossier de thèmes.
+- Modifications avancées : éditez les modules de `src/liquid/` (`main.css`, `color-*.css`, `font*.css`, `CodeMirror*.css`, `custom-*.css`).
+- Overrides via CSS personnalisé Typora : <https://support.typora.io/Add-Custom-CSS/>.
+
+## Dépannage
+
+- **Le thème n’apparaît pas** : vérifiez que les quatre `liquid*.css` sont à la racine du dossier de thèmes.
+- **Police/style Ink manquant** : vérifiez que `liquid/` est copié à côté des CSS.
+- **Systèmes sensibles à la casse** : utilisez les noms exacts attendus par le CSS (`Inkfree.ttf`, `FZSJ-SGLDXMHJW.TTF`).
 
 ## Documentation
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -28,80 +28,64 @@ typora-copy-images-to: ../../media/theme/Liquid
 
 [English](https://github.com/ruiyangzhou01/Liquid/blob/main/README.md) • [中文](https://github.com/ruiyangzhou01/Liquid/blob/main/README_zh.md) • [Deutsch](https://github.com/ruiyangzhou01/Liquid/blob/main/README_de.md) • [Español](https://github.com/ruiyangzhou01/Liquid/blob/main/README_es.md) • [Français](https://github.com/ruiyangzhou01/Liquid/blob/main/README_fr.md) • [日本語](https://github.com/ruiyangzhou01/Liquid/blob/main/README_ja.md)
 
-Liquid は [Microsoft Fluent Design](https://www.microsoft.com/design/fluent/#/) と [Purple Theme](https://github.com/hliu202/typora-purple-theme) に着想を得た Typora テーマです。グラデーション、ミカ調の質感、角丸の形状、同梱フォントによって Windows 11 風の読書・執筆体験を提供します。テーマはモジュール化された CSS を基に 4 種類のバリエーションを用意しています。
+Liquid は [Microsoft Fluent Design](https://www.microsoft.com/design/fluent/#/) と [Purple Theme](https://github.com/hliu202/typora-purple-theme) に着想を得た Typora テーマです。現在のリポジトリでは、`src/` に実運用可能なテーマファイルを直接配置しています（`dist/` の別ビルド成果物はありません）。
 
-## 機能
+## 現在の状態
 
-- グラデーション、ミカ、角丸、カラフルなインジケーターによる Fluent Design 風スタイル
-- 4 つのバリエーション：Light、Dark、Ink、Ink Dark
-- コードブロック向けの CodeMirror カスタムスタイル
-- セリフ体、手書き体、等幅フォントを同梱
+- 継続メンテナンス中、4 バリアントを提供：`liquid` / `liquid-dark` / `liquid-ink` / `liquid-ink-dark`
+- ソース CSS とフォントをリポジトリに同梱
+- ドキュメントと翻訳を現行構成に合わせて更新
 
-## 対応環境
+## 特徴
 
-- Windows 10 / Windows 11
-- Typora デスクトップアプリ
-- 対応言語：英語・中国語（Source Han Serif CN）。Ink モードでは Ink Free と FZSJ-SGLDXMHJW を手書きフォントとして使用します。
+- Fluent スタイル（グラデーション、角丸、アクセント表示）
+- Light / Dark / Ink / Ink Dark の 4 モード
+- CodeMirror のカスタムスタイル
+- セリフ体・等幅・Ink 手書き向けフォントを同梱
 
-## スクリーンショット
+## リポジトリ構成
 
-Liquid Theme は Typora に Windows 11 のモダンな視覚体験を提供します。グラデーション、ミカ素材、角丸矩形などの UI 要素を活用し、英語と中国語に対応した Light Mode、Dark Mode、Ink Mode、Ink Dark Mode を用意しています。
-
-![preview](/media/theme/liquid/preview.png)
-
-### Light Mode
-
-![light-preview1](/media/theme/liquid/light-preview1.png)
-
-![light-preview2](/media/theme/liquid/light-preview2.png)
-
-![light-preview3](/media/theme/liquid/light-preview3.png)
-
-### Dark Mode
-
-![dark-preview1](/media/theme/liquid/dark-preview1.png)
-
-![dark-preview2](/media/theme/liquid/dark-preview2.png)
-
-![dark-preview3](/media/theme/liquid/dark-preview3.png)
-
-### Ink Mode & Ink Dark Mode
-
-Microsoft Surface のような 2-in-1 PC で学習や執筆を行う場合や、手書きフォントが好きな場合は、Ink Mode が Typora に手書き風の読書・執筆体験を提供します。
-
-![ink-preview1](/media/theme/liquid/ink-preview1.png)
-
-![ink-preview2](/media/theme/liquid/ink-preview2.png)
-
-![ink-preview3](/media/theme/liquid/ink-preview3.png)
+```text
+src/
+  liquid.css
+  liquid-dark.css
+  liquid-ink.css
+  liquid-ink-dark.css
+  liquid/
+    *.css
+    *.ttf
+    *.woff2
+Demo.md
+README*.md
+doc/Document*.md
+media/
+assets/
+```
 
 ## インストール
 
-1. [Releases](https://github.com/ruiyangzhou01/Liquid/releases) から `liquid.zip` をダウンロードします。
+1. [Releases](https://github.com/ruiyangzhou01/Liquid/releases) から `liquid.zip` を取得するか、リポジトリを clone します。
 2. Typora の **Preferences** → **Appearance** → **Open Theme Folder** を開きます。
-3. `liquid.css`、`liquid-dark.css`、`liquid-ink.css`、`liquid-ink-dark.css`、および `liquid/` フォントフォルダをテーマフォルダへ展開・コピーします。
-4. Typora を再起動します。
-5. **Themes** メニューから Liquid を選択します。
-6. このリポジトリ（またはソースコードアーカイブ）の `Demo.md` を開き、表示を確認します。
-
-### Ink モードのフォント
-
-Liquid には Ink 用フォントが同梱され、`@font-face` で読み込まれるため、通常はシステムへのインストールは不要です。大文字小文字を区別する環境では `liquid/` フォルダのファイル名が CSS の参照（`inkfree.ttf` と `FZSJ-SGLDXMHJW.ttf`）と一致するよう確認し、必要に応じてリネームまたは CSS を調整してください。`FZSJ-SGLDXMHJW` は Ink モードの中国語、`Inkfree` はラテン文字の手書き用です。
-
-## ソースからビルド
-
-ビルドスクリプトは Windows のパス表記を前提にしています。
-
-1. Python 3 をインストールします。
-2. `cd src/Deploy` を実行します。
-3. `python CombineCSS.py` を実行し、`src/liquid*.css` を `dist/*.css` に結合します。
-4. （任意）`cd ../deploy` と `python CompressZip.py` を実行して `dist` を `liquid.zip` としてパッケージします。
+3. 以下をテーマフォルダにコピーします：
+   - `src/liquid.css`
+   - `src/liquid-dark.css`
+   - `src/liquid-ink.css`
+   - `src/liquid-ink-dark.css`
+   - `src/liquid/`（フォルダごと）
+4. Typora を再起動し、Liquid テーマを選択します。
+5. `Demo.md` を開いて表示を確認します。
 
 ## カスタマイズ
 
-- Typora のカスタム CSS を使う（推奨）：<https://support.typora.io/Add-Custom-CSS/>。
-- テーマフォルダ内のコンパイル済みファイルを編集する（このリポジトリの `dist/*.css`）。
-- さらに調整する場合は `src/liquid/` のモジュールを編集して再ビルドします。詳細は下記のドキュメントを参照してください。
+- 手早い調整：テーマフォルダ内の `liquid*.css` を直接編集。
+- 詳細調整：`src/liquid/` のモジュール（`main.css`、`color-*.css`、`font*.css`、`CodeMirror*.css`、`custom-*.css`）を編集。
+- Typora カスタム CSS で上書き追加：<https://support.typora.io/Add-Custom-CSS/>。
+
+## トラブルシューティング
+
+- **テーマが表示されない**：4 つの `liquid*.css` がテーマフォルダ直下にあるか確認。
+- **Ink フォントが反映されない**：`liquid/` フォルダが CSS と同じ場所にあるか確認。
+- **大文字小文字区別環境で文字欠け**：CSS 参照名（`Inkfree.ttf`、`FZSJ-SGLDXMHJW.TTF`）とファイル名を一致させてください。
 
 ## ドキュメント
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -28,80 +28,64 @@ typora-copy-images-to: ../../media/theme/Liquid
 
 [English](https://github.com/ruiyangzhou01/Liquid/blob/main/README.md) • [中文](https://github.com/ruiyangzhou01/Liquid/blob/main/README_zh.md) • [Deutsch](https://github.com/ruiyangzhou01/Liquid/blob/main/README_de.md) • [Español](https://github.com/ruiyangzhou01/Liquid/blob/main/README_es.md) • [Français](https://github.com/ruiyangzhou01/Liquid/blob/main/README_fr.md) • [日本語](https://github.com/ruiyangzhou01/Liquid/blob/main/README_ja.md)
 
-Liquid 是一个 Typora 主题，灵感来自 [Microsoft Fluent Design](https://www.microsoft.com/design/fluent/#/) 和 [Purple Theme](https://github.com/hliu202/typora-purple-theme)。它通过渐变、云母质感、圆角矩形和内置字体提供 Windows 11 风格的阅读与写作体验。主题包含四个基于模块化 CSS 的模式。
+Liquid 是一个受 [Microsoft Fluent Design](https://www.microsoft.com/design/fluent/#/) 与 [Purple Theme](https://github.com/hliu202/typora-purple-theme) 启发的 Typora 主题。当前仓库直接提供 `src/` 下可用的主题源码（不再有独立 `dist/` 构建产物）。
+
+## 当前状态
+
+- 持续维护，提供四个模式：`liquid`、`liquid-dark`、`liquid-ink`、`liquid-ink-dark`
+- 源码 CSS 与字体文件直接在仓库中维护
+- 文档与翻译已按当前仓库结构更新
 
 ## 特性
 
-- Fluent Design 风格：渐变、云母、圆角矩形和彩色指示
-- 四种模式：Light、Dark、Ink 和 Ink Dark
-- 定制的 CodeMirror 代码块样式
-- 内置衬线、手写和等宽字体
+- Fluent 风格视觉：渐变、圆角、强调色指示、类云母质感
+- Light / Dark / Ink / Ink Dark 四种模式
+- 定制 CodeMirror 代码块样式
+- 内置衬线、等宽和 Ink 手写风格字体
 
-## 兼容性
+## 仓库结构
 
-- Windows 10 和 Windows 11
-- Typora 桌面版
-- 语言覆盖：英文与中文（Source Han Serif CN）。Ink 模式还使用 Ink Free 与 FZSJ-SGLDXMHJW 作为手写字体。
-
-## 截图
-
-Liquid Theme 旨在为 Windows 11 中的 Typora 提供现代化视觉体验。它使用了现代 UI 元素，如渐变、云母材质和圆角矩形。主题支持中文和英文，并提供 Light Mode、Dark Mode、Ink Mode 和 Ink Dark Mode。
-
-![preview](/media/theme/liquid/preview.png)
-
-### Light Mode
-
-![light-preview1](/media/theme/liquid/light-preview1.png)
-
-![light-preview2](/media/theme/liquid/light-preview2.png)
-
-![light-preview3](/media/theme/liquid/light-preview3.png)
-
-### Dark Mode
-
-![dark-preview1](/media/theme/liquid/dark-preview1.png)
-
-![dark-preview2](/media/theme/liquid/dark-preview2.png)
-
-![dark-preview3](/media/theme/liquid/dark-preview3.png)
-
-### Ink Mode & Ink Dark Mode
-
-如果你使用像 Microsoft Surface 这样的二合一电脑来学习和写作，或者只是喜欢手写字体，那么 Ink Mode 可以在 Typora 中提供手写风格的阅读和书写体验。
-
-![ink-preview1](/media/theme/liquid/ink-preview1.png)
-
-![ink-preview2](/media/theme/liquid/ink-preview2.png)
-
-![ink-preview3](/media/theme/liquid/ink-preview3.png)
+```text
+src/
+  liquid.css
+  liquid-dark.css
+  liquid-ink.css
+  liquid-ink-dark.css
+  liquid/
+    *.css
+    *.ttf
+    *.woff2
+Demo.md
+README*.md
+doc/Document*.md
+media/
+assets/
+```
 
 ## 安装
 
-1. 从 [Releases](https://github.com/ruiyangzhou01/Liquid/releases) 页面下载 `liquid.zip`。
-2. 在 Typora 设置中，点击 **偏好设置**，选择 **界面**，然后点击 **打开主题文件夹**。
-3. 解压并复制 `liquid.css`、`liquid-dark.css`、`liquid-ink.css`、`liquid-ink-dark.css` 和 `liquid/` 字体文件夹到主题目录。
-4. 重启 Typora。
-5. 在 Typora 的 **主题** 菜单中选择 Liquid 主题。
-6. 打开本仓库中的 `Demo.md`（或源码压缩包）预览渲染效果。
-
-### Ink 模式字体
-
-Liquid 已通过 `@font-face` 打包 Ink 字体，通常不需要系统安装。在区分大小写的文件系统中，请确认 `liquid/` 目录的字体文件名与 CSS 引用一致（`inkfree.ttf` 与 `FZSJ-SGLDXMHJW.ttf`），必要时重命名或修改 CSS。`FZSJ-SGLDXMHJW` 用于 Ink 模式中文字符，`Inkfree` 用于拉丁字符的手写字体。
-
-## 从源码构建
-
-构建脚本使用 Windows 路径编写。
-
-1. 安装 Python 3。
-2. 运行 `cd src/Deploy`。
-3. 运行 `python CombineCSS.py`，将 `src/liquid*.css` 合并到 `dist/*.css`。
-4. （可选）运行 `cd ../deploy` 和 `python CompressZip.py`，将 `dist` 打包为 `liquid.zip`。
+1. 从 [Releases](https://github.com/ruiyangzhou01/Liquid/releases) 下载 `liquid.zip`，或直接克隆仓库。
+2. 打开 Typora → **偏好设置** → **外观** → **打开主题文件夹**。
+3. 将以下文件复制到 Typora 主题目录：
+   - `src/liquid.css`
+   - `src/liquid-dark.css`
+   - `src/liquid-ink.css`
+   - `src/liquid-ink-dark.css`
+   - `src/liquid/`（整个目录）
+4. 重启 Typora，在 **主题** 菜单中选择 Liquid 模式。
+5. 打开 `Demo.md` 预览效果。
 
 ## 自定义
 
-- 通过 Typora 自定义 CSS（推荐）：<https://support.typora.io/Add-Custom-CSS/>。
-- 编辑主题目录中的编译后文件（本仓库的 `dist/*.css`）。
-- 深度定制可编辑 `src/liquid/` 模块并重新构建，详情参见下方文档。
+- 快速调整：直接编辑主题目录中的 `liquid*.css`。
+- 深度定制：编辑 `src/liquid/` 模块（`main.css`、`color-*.css`、`font*.css`、`CodeMirror*.css`、`custom-*.css`）。
+- 通过 Typora 自定义 CSS 添加覆盖层：<https://support.typora.io/Add-Custom-CSS/>。
+
+## 故障排查
+
+- **Typora 中看不到主题**：确认四个 `liquid*.css` 已复制到主题目录根路径。
+- **字体或 Ink 效果缺失**：确认 `liquid/` 目录与 CSS 文件处于同级。
+- **区分大小写系统出现缺字**：检查字体文件名大小写与 CSS 引用一致（如 `Inkfree.ttf`、`FZSJ-SGLDXMHJW.TTF`）。
 
 ## 文档
 

--- a/doc/Document.md
+++ b/doc/Document.md
@@ -4,54 +4,17 @@
 
 ## Overview
 
-Liquid is a Typora theme inspired by Microsoft Fluent Design. This document explains the file layout, build workflow, and customization options based on the current repository structure.
+Liquid is a Typora theme inspired by Microsoft Fluent Design. The current repository is source-first: theme entry files and modules are kept directly under `src/`.
 
-## File Structure
-
-### Release Package (`liquid.zip`)
-
-The release archive is produced from the `dist` folder and contains the compiled CSS plus fonts:
+## Repository layout
 
 ```text
-liquid.css
-liquid-dark.css
-liquid-ink.css
-liquid-ink-dark.css
-liquid/
-  JetBrainsMono-Bold.woff2
-  JetBrainsMono-Regular.woff2
-  SourceHanSerifCN-Bold.ttf
-  SourceHanSerifCN-Regular.ttf
-  Inkfree.ttf
-  FZSJ-SGLDXMHJW.TTF
-```
-
-### Repository Layout
-
-```text
-Demo.md
-README.md
-README_*.md
-LICENSE
-media/                # preview images
-font/                 # raw font sources
-  JetBrainsMono-2.242/
-  SourceHanSerifCN/
-dist/                 # compiled CSS + font assets (release contents)
+src/
   liquid.css
   liquid-dark.css
   liquid-ink.css
   liquid-ink-dark.css
   liquid/
-    *.ttf
-    *.woff2
-doc/                  # documentation translations
-src/
-  liquid.css           # entry point (light)
-  liquid-dark.css      # entry point (dark)
-  liquid-ink.css       # entry point (ink)
-  liquid-ink-dark.css  # entry point (ink dark)
-  liquid/              # CSS modules
     main.css
     color-light.css
     color-dark.css
@@ -61,58 +24,55 @@ src/
     CodeMirror-dark.css
     custom-ink.css
     custom-dark.css
-  Deploy/CombineCSS.py # combines @import files into dist
-  deploy/CompressZip.py # packages dist into liquid.zip
+    Inkfree.ttf
+    FZSJ-SGLDXMHJW.TTF
+    SourceHanSerifCN-*.ttf
+    JetBrainsMono-*.woff2
+Demo.md
+doc/Document*.md
+README*.md
+media/
+assets/
 ```
 
-## Build From Source
+## Theme variants
 
-The build scripts use Windows-style paths and are intended to run on Windows. CombineCSS.py lives in `src/Deploy` (capital D) and CompressZip.py in `src/deploy` (lowercase). On case-sensitive file systems, use the exact folder names.
+- `liquid.css`: light mode
+- `liquid-dark.css`: dark mode
+- `liquid-ink.css`: ink mode
+- `liquid-ink-dark.css`: ink dark mode
 
-1. Install Python 3.
-2. Run `cd src/Deploy`.
-3. Run `python CombineCSS.py` to recursively expand `@import` statements and write the compiled files into `dist/`.
-4. (Optional) Run `cd ../deploy` and `python CompressZip.py` to create `liquid.zip` from the `dist` folder.
+## How to install
 
-## CSS Module Map
+1. Open Typora theme folder from **Preferences → Appearance → Open Theme Folder**.
+2. Copy the four `src/liquid*.css` files into that folder.
+3. Copy the full `src/liquid/` folder next to the CSS files.
+4. Restart Typora and select a Liquid variant.
 
-The entry-point CSS files in `src/` import smaller modules under `src/liquid/`:
+## Module map
 
-- `liquid.css`: light mode (imports `font.css`, `color-light.css`, `CodeMirror.css`, `main.css`).
-- `liquid-dark.css`: dark mode (imports `font.css`, `color-dark.css`, `CodeMirror-dark.css`, `main.css`, `custom-dark.css`).
-- `liquid-ink.css`: ink mode (imports `font-ink.css`, `color-light.css`, `CodeMirror.css`, `main.css`, `custom-ink.css`).
-- `liquid-ink-dark.css`: ink dark mode (imports `font-ink.css`, `color-dark.css`, `CodeMirror-dark.css`, `main.css`, `custom-ink.css`, `custom-dark.css`).
+Entry files import modules from `src/liquid/`:
 
-Key modules:
+- Typography/layout: `main.css`
+- Color tokens: `color-light.css`, `color-dark.css`
+- Font stacks: `font.css`, `font-ink.css`
+- Code block styles: `CodeMirror.css`, `CodeMirror-dark.css`
+- Variant overrides: `custom-ink.css`, `custom-dark.css`
 
-- `main.css`: shared layout, typography, and component styling.
-- `color-light.css` / `color-dark.css`: color variables for light and dark palettes.
-- `font.css`: default fonts (Source Han Serif CN + JetBrains Mono).
-- `font-ink.css`: handwriting fonts (Ink Free + FZSJ-SGLDXMHJW).
-- `CodeMirror.css` / `CodeMirror-dark.css`: code block theme styles.
-- `custom-ink.css`: ink-specific typography adjustments.
-- `custom-dark.css`: dark-mode UI tweaks.
+## Customization workflow
 
-## Customization Options
+1. Start with direct CSS edits in installed `liquid*.css` if you only need quick adjustments.
+2. For structural changes, edit module files in `src/liquid/`.
+3. Keep your personal overrides in Typora custom CSS whenever possible to simplify updates.
 
-### 1. Add Custom CSS (Recommended)
+## Font notes
 
-Use Typora’s custom CSS support to layer your own overrides without touching the theme files. Refer to <https://support.typora.io/Add-Custom-CSS/>.
+- Ink variants use `Inkfree` for Latin handwriting-like text and `FZSJ-SGLDXMHJW` for Chinese handwriting style.
+- Fonts are loaded via `@font-face` from the local `liquid/` folder.
+- On case-sensitive file systems, ensure font filename case matches CSS references.
 
-### 2. Edit the Compiled Theme Files
+## Troubleshooting
 
-After installing the theme, edit `liquid.css`, `liquid-dark.css`, `liquid-ink.css`, or `liquid-ink-dark.css` directly in your theme folder. Keep the `liquid/` font folder next to the CSS files so the `@font-face` declarations continue to resolve.
-
-### 3. Edit the Source Modules
-
-For deeper changes, edit the module files under `src/liquid/` and rebuild with `CombineCSS.py`. Typical adjustments include:
-
-- Colors: `color-light.css` and `color-dark.css`
-- Fonts: `font.css` and `font-ink.css`
-- Code blocks: `CodeMirror.css` and `CodeMirror-dark.css`
-- Ink/dark tweaks: `custom-ink.css` and `custom-dark.css`
-- Layout and typography: `main.css`
-
-## Font Notes
-
-Ink modes rely on `Inkfree` for Latin handwriting and `FZSJ-SGLDXMHJW` for Chinese handwriting. The fonts are bundled and loaded via `@font-face`, so system-wide installation is usually unnecessary. On case-sensitive file systems, ensure the filenames in `liquid/` match the CSS references (`inkfree.ttf` and `FZSJ-SGLDXMHJW.ttf`), or rename the files/update the CSS to match.
+- Theme not listed: verify all four `liquid*.css` files are in the theme folder root.
+- Font not applied: verify `liquid/` folder is copied beside the CSS files.
+- Styles not changing: disable custom CSS temporarily to rule out selector conflicts.

--- a/doc/Document_de.md
+++ b/doc/Document_de.md
@@ -3,116 +3,32 @@
 [English](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document.md) • [中文](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_zh.md) • [Deutsch](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_de.md) • [Español](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_es.md) • [Français](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_fr.md) • [日本語](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_ja.md)
 
 ## Überblick
+Liquid ist ein Typora-Theme im Fluent-Stil. Die aktuelle Struktur ist source-first: alles liegt unter `src/`.
 
-Liquid ist ein Typora-Theme, das von Microsoft Fluent Design inspiriert wurde. Dieses Dokument beschreibt die Dateistruktur, den Build-Workflow und die Anpassungsmöglichkeiten basierend auf dem aktuellen Repository.
+## Struktur
+- Einstieg: `src/liquid.css`, `src/liquid-dark.css`, `src/liquid-ink.css`, `src/liquid-ink-dark.css`
+- Module und Fonts: `src/liquid/`
+- Vorschau: `Demo.md`
+- Doku: `doc/Document*.md`
 
-## Dateistruktur
+## Installation
+1. Typora-Theme-Ordner öffnen.
+2. Vier `src/liquid*.css` kopieren.
+3. Ordner `src/liquid/` daneben kopieren.
+4. Typora neu starten und Theme wählen.
 
-### Release-Paket (`liquid.zip`)
+## Module
+- Layout: `main.css`
+- Farben: `color-light.css`, `color-dark.css`
+- Schrift: `font.css`, `font-ink.css`
+- Code: `CodeMirror.css`, `CodeMirror-dark.css`
+- Overrides: `custom-ink.css`, `custom-dark.css`
 
-Das Release-Archiv wird aus dem Ordner `dist` erzeugt und enthält die kompilierten CSS-Dateien sowie die Schriftarten:
+## Hinweise
+- Ink nutzt `Inkfree` und `FZSJ-SGLDXMHJW`.
+- Auf dateisensitiven Systemen Dateinamen exakt beibehalten.
 
-```text
-liquid.css
-liquid-dark.css
-liquid-ink.css
-liquid-ink-dark.css
-liquid/
-  JetBrainsMono-Bold.woff2
-  JetBrainsMono-Regular.woff2
-  SourceHanSerifCN-Bold.ttf
-  SourceHanSerifCN-Regular.ttf
-  Inkfree.ttf
-  FZSJ-SGLDXMHJW.TTF
-```
-
-### Repository-Layout
-
-```text
-Demo.md
-README.md
-README_*.md
-LICENSE
-media/                # Vorschaubilder
-font/                 # Originale Schriftquellen
-  JetBrainsMono-2.242/
-  SourceHanSerifCN/
-dist/                 # Kompilierte CSS + Schrift-Assets (Release-Inhalt)
-  liquid.css
-  liquid-dark.css
-  liquid-ink.css
-  liquid-ink-dark.css
-  liquid/
-    *.ttf
-    *.woff2
-doc/                  # Übersetzte Dokumentation
-src/
-  liquid.css           # Einstieg (light)
-  liquid-dark.css      # Einstieg (dark)
-  liquid-ink.css       # Einstieg (ink)
-  liquid-ink-dark.css  # Einstieg (ink dark)
-  liquid/              # CSS-Module
-    main.css
-    color-light.css
-    color-dark.css
-    font.css
-    font-ink.css
-    CodeMirror.css
-    CodeMirror-dark.css
-    custom-ink.css
-    custom-dark.css
-  Deploy/CombineCSS.py # kombiniert @import in dist
-  deploy/CompressZip.py # packt dist als liquid.zip
-```
-
-## Build aus dem Quellcode
-
-Die Build-Skripte verwenden Windows-Pfade und sind für Windows gedacht. CombineCSS.py liegt unter `src/Deploy` (großes D) und CompressZip.py unter `src/deploy` (kleines d). Auf dateisensitiven Systemen die genaue Schreibweise verwenden.
-
-1. Python 3 installieren.
-2. `cd src/Deploy` ausführen.
-3. `python CombineCSS.py` ausführen, um `@import` rekursiv zu erweitern und nach `dist/` zu schreiben.
-4. (Optional) `cd ../deploy` und `python CompressZip.py` ausführen, um `liquid.zip` aus `dist` zu erzeugen.
-
-## CSS-Modulübersicht
-
-Die Einstiegspunkte unter `src/` importieren Module aus `src/liquid/`:
-
-- `liquid.css`: Light-Modus (importiert `font.css`, `color-light.css`, `CodeMirror.css`, `main.css`).
-- `liquid-dark.css`: Dark-Modus (importiert `font.css`, `color-dark.css`, `CodeMirror-dark.css`, `main.css`, `custom-dark.css`).
-- `liquid-ink.css`: Ink-Modus (importiert `font-ink.css`, `color-light.css`, `CodeMirror.css`, `main.css`, `custom-ink.css`).
-- `liquid-ink-dark.css`: Ink-Dark-Modus (importiert `font-ink.css`, `color-dark.css`, `CodeMirror-dark.css`, `main.css`, `custom-ink.css`, `custom-dark.css`).
-
-Wichtige Module:
-
-- `main.css`: Gemeinsames Layout, Typografie und Komponenten.
-- `color-light.css` / `color-dark.css`: Farbvariablen für helle/dunkle Paletten.
-- `font.css`: Standardschriften (Source Han Serif CN + JetBrains Mono).
-- `font-ink.css`: Handschrift-Schriften (Ink Free + FZSJ-SGLDXMHJW).
-- `CodeMirror.css` / `CodeMirror-dark.css`: Styles für Codeblöcke.
-- `custom-ink.css`: Ink-spezifische Typografie-Anpassungen.
-- `custom-dark.css`: UI-Anpassungen für den Dark-Modus.
-
-## Anpassungsoptionen
-
-### 1. Eigenes CSS hinzufügen (empfohlen)
-
-Nutze Typoras benutzerdefiniertes CSS, um eigene Overrides hinzuzufügen. Siehe <https://support.typora.io/Add-Custom-CSS/>.
-
-### 2. Kompilierte Theme-Dateien bearbeiten
-
-Nach der Installation können `liquid.css`, `liquid-dark.css`, `liquid-ink.css` oder `liquid-ink-dark.css` im Theme-Ordner direkt angepasst werden. Der Ordner `liquid/` mit den Schriftarten muss neben den CSS-Dateien bleiben, damit `@font-face` funktioniert.
-
-### 3. Quellmodule bearbeiten
-
-Für tiefere Anpassungen bearbeite die Module unter `src/liquid/` und baue mit `CombineCSS.py` neu. Typische Änderungen:
-
-- Farben: `color-light.css` und `color-dark.css`
-- Schriften: `font.css` und `font-ink.css`
-- Codeblöcke: `CodeMirror.css` und `CodeMirror-dark.css`
-- Ink/Dark-Anpassungen: `custom-ink.css` und `custom-dark.css`
-- Layout und Typografie: `main.css`
-
-## Hinweise zu Schriftarten
-
-Die Ink-Modi nutzen `Inkfree` für lateinische Handschrift und `FZSJ-SGLDXMHJW` für chinesische Zeichen. Die Schriften sind gebündelt und werden via `@font-face` geladen, daher ist eine systemweite Installation meist nicht nötig. Auf dateisensitiven Systemen müssen die Dateinamen im Ordner `liquid/` den CSS-Referenzen entsprechen (`inkfree.ttf` und `FZSJ-SGLDXMHJW.ttf`), andernfalls Dateien umbenennen oder das CSS anpassen.
+## Fehlerbehebung
+- Theme fehlt: prüfen, ob alle vier CSS-Dateien im Theme-Ordner liegen.
+- Schrift fehlt: prüfen, ob `liquid/` neben den CSS-Dateien liegt.
+- Keine Änderung sichtbar: testweise Custom CSS deaktivieren.

--- a/doc/Document_es.md
+++ b/doc/Document_es.md
@@ -2,117 +2,33 @@
 
 [English](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document.md) • [中文](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_zh.md) • [Deutsch](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_de.md) • [Español](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_es.md) • [Français](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_fr.md) • [日本語](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_ja.md)
 
-## Descripción general
+## Resumen
+Liquid es un tema de Typora con estilo Fluent. La estructura actual del proyecto usa `src/` como fuente principal.
 
-Liquid es un tema de Typora inspirado en Microsoft Fluent Design. Este documento explica la estructura de archivos, el flujo de compilación y las opciones de personalización según el repositorio actual.
+## Estructura
+- Entradas: `src/liquid.css`, `src/liquid-dark.css`, `src/liquid-ink.css`, `src/liquid-ink-dark.css`
+- Módulos y fuentes: `src/liquid/`
+- Vista previa: `Demo.md`
+- Documentación: `doc/Document*.md`
 
-## Estructura de archivos
+## Instalación
+1. Abre la carpeta de temas de Typora.
+2. Copia los cuatro `src/liquid*.css`.
+3. Copia la carpeta completa `src/liquid/` junto a los CSS.
+4. Reinicia Typora y selecciona el tema.
 
-### Paquete de lanzamiento (`liquid.zip`)
+## Módulos
+- Diseño: `main.css`
+- Colores: `color-light.css`, `color-dark.css`
+- Fuentes: `font.css`, `font-ink.css`
+- Código: `CodeMirror.css`, `CodeMirror-dark.css`
+- Ajustes: `custom-ink.css`, `custom-dark.css`
 
-El archivo de lanzamiento se genera a partir de la carpeta `dist` y contiene el CSS compilado y las fuentes:
+## Notas
+- Ink usa `Inkfree` y `FZSJ-SGLDXMHJW`.
+- En sistemas sensibles a mayúsculas/minúsculas, respeta exactamente los nombres de archivo.
 
-```text
-liquid.css
-liquid-dark.css
-liquid-ink.css
-liquid-ink-dark.css
-liquid/
-  JetBrainsMono-Bold.woff2
-  JetBrainsMono-Regular.woff2
-  SourceHanSerifCN-Bold.ttf
-  SourceHanSerifCN-Regular.ttf
-  Inkfree.ttf
-  FZSJ-SGLDXMHJW.TTF
-```
-
-### Estructura del repositorio
-
-```text
-Demo.md
-README.md
-README_*.md
-LICENSE
-media/                # imágenes de vista previa
-font/                 # fuentes originales
-  JetBrainsMono-2.242/
-  SourceHanSerifCN/
-dist/                 # CSS compilado + recursos de fuentes (contenido del release)
-  liquid.css
-  liquid-dark.css
-  liquid-ink.css
-  liquid-ink-dark.css
-  liquid/
-    *.ttf
-    *.woff2
-doc/                  # documentación traducida
-src/
-  liquid.css           # entrada (light)
-  liquid-dark.css      # entrada (dark)
-  liquid-ink.css       # entrada (ink)
-  liquid-ink-dark.css  # entrada (ink dark)
-  liquid/              # módulos CSS
-    main.css
-    color-light.css
-    color-dark.css
-    font.css
-    font-ink.css
-    CodeMirror.css
-    CodeMirror-dark.css
-    custom-ink.css
-    custom-dark.css
-  Deploy/CombineCSS.py # combina @import en dist
-  deploy/CompressZip.py # empaqueta dist como liquid.zip
-```
-
-## Compilar desde el código fuente
-
-Los scripts de compilación usan rutas de Windows y están pensados para Windows. CombineCSS.py está en `src/Deploy` (D mayúscula) y CompressZip.py en `src/deploy` (d minúscula). En sistemas sensibles a mayúsculas utiliza el nombre exacto.
-
-1. Instala Python 3.
-2. Ejecuta `cd src/Deploy`.
-3. Ejecuta `python CombineCSS.py` para expandir recursivamente `@import` y escribir en `dist/`.
-4. (Opcional) Ejecuta `cd ../deploy` y `python CompressZip.py` para crear `liquid.zip` desde `dist`.
-
-## Mapa de módulos CSS
-
-Los archivos de entrada en `src/` importan módulos en `src/liquid/`:
-
-- `liquid.css`: modo light (importa `font.css`, `color-light.css`, `CodeMirror.css`, `main.css`).
-- `liquid-dark.css`: modo dark (importa `font.css`, `color-dark.css`, `CodeMirror-dark.css`, `main.css`, `custom-dark.css`).
-- `liquid-ink.css`: modo ink (importa `font-ink.css`, `color-light.css`, `CodeMirror.css`, `main.css`, `custom-ink.css`).
-- `liquid-ink-dark.css`: modo ink dark (importa `font-ink.css`, `color-dark.css`, `CodeMirror-dark.css`, `main.css`, `custom-ink.css`, `custom-dark.css`).
-
-Módulos clave:
-
-- `main.css`: diseño compartido, tipografía y componentes.
-- `color-light.css` / `color-dark.css`: variables de color para paletas claras y oscuras.
-- `font.css`: fuentes predeterminadas (Source Han Serif CN + JetBrains Mono).
-- `font-ink.css`: fuentes manuscritas (Ink Free + FZSJ-SGLDXMHJW).
-- `CodeMirror.css` / `CodeMirror-dark.css`: estilos para bloques de código.
-- `custom-ink.css`: ajustes tipográficos del modo Ink.
-- `custom-dark.css`: ajustes de UI del modo oscuro.
-
-## Opciones de personalización
-
-### 1. Añadir CSS personalizado (recomendado)
-
-Usa el CSS personalizado de Typora para añadir tus propias modificaciones. Consulta <https://support.typora.io/Add-Custom-CSS/>.
-
-### 2. Editar los archivos compilados
-
-Tras instalar el tema, edita directamente `liquid.css`, `liquid-dark.css`, `liquid-ink.css` o `liquid-ink-dark.css` en la carpeta del tema. Mantén la carpeta `liquid/` junto a los CSS para que las declaraciones `@font-face` se resuelvan correctamente.
-
-### 3. Editar los módulos fuente
-
-Para cambios profundos, edita los módulos en `src/liquid/` y recompila con `CombineCSS.py`. Ajustes típicos:
-
-- Colores: `color-light.css` y `color-dark.css`
-- Fuentes: `font.css` y `font-ink.css`
-- Bloques de código: `CodeMirror.css` y `CodeMirror-dark.css`
-- Ajustes Ink/Dark: `custom-ink.css` y `custom-dark.css`
-- Diseño y tipografía: `main.css`
-
-## Notas sobre fuentes
-
-Los modos Ink usan `Inkfree` para manuscrito latino y `FZSJ-SGLDXMHJW` para caracteres chinos. Las fuentes se incluyen y se cargan mediante `@font-face`, por lo que normalmente no hace falta instalarlas en el sistema. En sistemas sensibles a mayúsculas, asegúrate de que los nombres de archivo en `liquid/` coincidan con el CSS (`inkfree.ttf` y `FZSJ-SGLDXMHJW.ttf`), o renombra los archivos/ajusta el CSS.
+## Solución de problemas
+- No aparece el tema: verifica los cuatro CSS en la carpeta de temas.
+- No se aplican fuentes: verifica que `liquid/` esté junto a los CSS.
+- No ves cambios: desactiva temporalmente CSS personalizado.

--- a/doc/Document_fr.md
+++ b/doc/Document_fr.md
@@ -3,116 +3,32 @@
 [English](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document.md) • [中文](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_zh.md) • [Deutsch](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_de.md) • [Español](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_es.md) • [Français](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_fr.md) • [日本語](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_ja.md)
 
 ## Vue d’ensemble
+Liquid est un thème Typora de style Fluent. Le dépôt actuel utilise une structure source-first sous `src/`.
 
-Liquid est un thème Typora inspiré de Microsoft Fluent Design. Ce document décrit l’organisation des fichiers, le workflow de build et les options de personnalisation selon le dépôt actuel.
+## Structure
+- Entrées : `src/liquid.css`, `src/liquid-dark.css`, `src/liquid-ink.css`, `src/liquid-ink-dark.css`
+- Modules et polices : `src/liquid/`
+- Démo : `Demo.md`
+- Documentation : `doc/Document*.md`
 
-## Structure des fichiers
+## Installation
+1. Ouvrez le dossier de thèmes Typora.
+2. Copiez les quatre `src/liquid*.css`.
+3. Copiez le dossier complet `src/liquid/` à côté des CSS.
+4. Redémarrez Typora et sélectionnez le thème.
 
-### Paquet de release (`liquid.zip`)
+## Modules
+- Mise en page : `main.css`
+- Couleurs : `color-light.css`, `color-dark.css`
+- Polices : `font.css`, `font-ink.css`
+- Code : `CodeMirror.css`, `CodeMirror-dark.css`
+- Ajustements : `custom-ink.css`, `custom-dark.css`
 
-L’archive de release est générée à partir du dossier `dist` et contient le CSS compilé et les polices :
+## Notes
+- Le mode Ink utilise `Inkfree` et `FZSJ-SGLDXMHJW`.
+- Sur les systèmes sensibles à la casse, gardez exactement les noms de fichiers.
 
-```text
-liquid.css
-liquid-dark.css
-liquid-ink.css
-liquid-ink-dark.css
-liquid/
-  JetBrainsMono-Bold.woff2
-  JetBrainsMono-Regular.woff2
-  SourceHanSerifCN-Bold.ttf
-  SourceHanSerifCN-Regular.ttf
-  Inkfree.ttf
-  FZSJ-SGLDXMHJW.TTF
-```
-
-### Organisation du dépôt
-
-```text
-Demo.md
-README.md
-README_*.md
-LICENSE
-media/                # images d’aperçu
-font/                 # sources des polices
-  JetBrainsMono-2.242/
-  SourceHanSerifCN/
-dist/                 # CSS compilé + ressources (contenu du release)
-  liquid.css
-  liquid-dark.css
-  liquid-ink.css
-  liquid-ink-dark.css
-  liquid/
-    *.ttf
-    *.woff2
-doc/                  # documentation traduite
-src/
-  liquid.css           # entrée (light)
-  liquid-dark.css      # entrée (dark)
-  liquid-ink.css       # entrée (ink)
-  liquid-ink-dark.css  # entrée (ink dark)
-  liquid/              # modules CSS
-    main.css
-    color-light.css
-    color-dark.css
-    font.css
-    font-ink.css
-    CodeMirror.css
-    CodeMirror-dark.css
-    custom-ink.css
-    custom-dark.css
-  Deploy/CombineCSS.py # combine @import vers dist
-  deploy/CompressZip.py # empaquette dist en liquid.zip
-```
-
-## Construire depuis la source
-
-Les scripts de build utilisent des chemins Windows et sont prévus pour Windows. CombineCSS.py se trouve dans `src/Deploy` (D majuscule) et CompressZip.py dans `src/deploy` (d minuscule). Sur les systèmes sensibles à la casse, utilisez le nom exact.
-
-1. Installez Python 3.
-2. Exécutez `cd src/Deploy`.
-3. Exécutez `python CombineCSS.py` pour étendre `@import` de manière récursive et écrire dans `dist/`.
-4. (Optionnel) Exécutez `cd ../deploy` et `python CompressZip.py` pour créer `liquid.zip` à partir de `dist`.
-
-## Carte des modules CSS
-
-Les fichiers d’entrée dans `src/` importent les modules de `src/liquid/` :
-
-- `liquid.css` : mode light (importe `font.css`, `color-light.css`, `CodeMirror.css`, `main.css`).
-- `liquid-dark.css` : mode dark (importe `font.css`, `color-dark.css`, `CodeMirror-dark.css`, `main.css`, `custom-dark.css`).
-- `liquid-ink.css` : mode ink (importe `font-ink.css`, `color-light.css`, `CodeMirror.css`, `main.css`, `custom-ink.css`).
-- `liquid-ink-dark.css` : mode ink dark (importe `font-ink.css`, `color-dark.css`, `CodeMirror-dark.css`, `main.css`, `custom-ink.css`, `custom-dark.css`).
-
-Modules clés :
-
-- `main.css` : mise en page partagée, typographie et composants.
-- `color-light.css` / `color-dark.css` : variables de couleur pour palettes claires/sombres.
-- `font.css` : polices par défaut (Source Han Serif CN + JetBrains Mono).
-- `font-ink.css` : polices manuscrites (Ink Free + FZSJ-SGLDXMHJW).
-- `CodeMirror.css` / `CodeMirror-dark.css` : styles des blocs de code.
-- `custom-ink.css` : ajustements typographiques du mode Ink.
-- `custom-dark.css` : ajustements UI du mode sombre.
-
-## Options de personnalisation
-
-### 1. Ajouter du CSS personnalisé (recommandé)
-
-Utilisez le CSS personnalisé de Typora pour ajouter vos propres overrides. Voir <https://support.typora.io/Add-Custom-CSS/>.
-
-### 2. Modifier les fichiers compilés
-
-Après installation, modifiez directement `liquid.css`, `liquid-dark.css`, `liquid-ink.css` ou `liquid-ink-dark.css` dans le dossier du thème. Gardez le dossier `liquid/` à côté des fichiers CSS afin que `@font-face` fonctionne.
-
-### 3. Modifier les modules source
-
-Pour des changements plus profonds, modifiez les modules sous `src/liquid/` et reconstruisez avec `CombineCSS.py`. Modifications typiques :
-
-- Couleurs : `color-light.css` et `color-dark.css`
-- Polices : `font.css` et `font-ink.css`
-- Blocs de code : `CodeMirror.css` et `CodeMirror-dark.css`
-- Ajustements Ink/Dark : `custom-ink.css` et `custom-dark.css`
-- Mise en page et typographie : `main.css`
-
-## Notes sur les polices
-
-Les modes Ink utilisent `Inkfree` pour l’écriture manuscrite latine et `FZSJ-SGLDXMHJW` pour les caractères chinois. Les polices sont incluses et chargées via `@font-face`, donc l’installation système n’est généralement pas nécessaire. Sur les systèmes sensibles à la casse, assurez-vous que les noms de fichiers dans `liquid/` correspondent au CSS (`inkfree.ttf` et `FZSJ-SGLDXMHJW.ttf`), ou renommez les fichiers/modifiez le CSS.
+## Dépannage
+- Thème absent : vérifiez la présence des quatre CSS dans le dossier de thèmes.
+- Police absente : vérifiez que `liquid/` est copié à côté des CSS.
+- Aucun changement visuel : désactivez temporairement le CSS personnalisé.

--- a/doc/Document_ja.md
+++ b/doc/Document_ja.md
@@ -3,116 +3,32 @@
 [English](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document.md) • [中文](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_zh.md) • [Deutsch](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_de.md) • [Español](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_es.md) • [Français](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_fr.md) • [日本語](https://github.com/ruiyangzhou01/Liquid/blob/main/doc/Document_ja.md)
 
 ## 概要
+Liquid は Fluent スタイルの Typora テーマです。現在のリポジトリは `src/` を中心とした source-first 構成です。
 
-Liquid は Microsoft Fluent Design に着想を得た Typora テーマです。本ドキュメントでは、現在のリポジトリ構成に基づいたファイル配置、ビルド手順、カスタマイズ方法を説明します。
+## 構成
+- エントリー: `src/liquid.css`, `src/liquid-dark.css`, `src/liquid-ink.css`, `src/liquid-ink-dark.css`
+- モジュールとフォント: `src/liquid/`
+- デモ: `Demo.md`
+- ドキュメント: `doc/Document*.md`
 
-## ファイル構成
+## インストール
+1. Typora のテーマフォルダを開く。
+2. `src/liquid*.css` を 4 つコピー。
+3. `src/liquid/` フォルダを CSS と同じ場所にコピー。
+4. Typora を再起動してテーマを選択。
 
-### リリースパッケージ（`liquid.zip`）
+## モジュール
+- レイアウト: `main.css`
+- 色: `color-light.css`, `color-dark.css`
+- フォント: `font.css`, `font-ink.css`
+- コード: `CodeMirror.css`, `CodeMirror-dark.css`
+- 調整: `custom-ink.css`, `custom-dark.css`
 
-リリースアーカイブは `dist` フォルダから生成され、コンパイル済み CSS とフォントを含みます。
+## 注意点
+- Ink モードは `Inkfree` と `FZSJ-SGLDXMHJW` を使用。
+- 大文字小文字を区別する環境ではファイル名を厳密に一致させてください。
 
-```text
-liquid.css
-liquid-dark.css
-liquid-ink.css
-liquid-ink-dark.css
-liquid/
-  JetBrainsMono-Bold.woff2
-  JetBrainsMono-Regular.woff2
-  SourceHanSerifCN-Bold.ttf
-  SourceHanSerifCN-Regular.ttf
-  Inkfree.ttf
-  FZSJ-SGLDXMHJW.TTF
-```
-
-### リポジトリ構成
-
-```text
-Demo.md
-README.md
-README_*.md
-LICENSE
-media/                # プレビュー画像
-font/                 # フォントの元データ
-  JetBrainsMono-2.242/
-  SourceHanSerifCN/
-dist/                 # コンパイル済み CSS + フォント（リリース内容）
-  liquid.css
-  liquid-dark.css
-  liquid-ink.css
-  liquid-ink-dark.css
-  liquid/
-    *.ttf
-    *.woff2
-doc/                  # ドキュメント翻訳
-src/
-  liquid.css           # エントリ (light)
-  liquid-dark.css      # エントリ (dark)
-  liquid-ink.css       # エントリ (ink)
-  liquid-ink-dark.css  # エントリ (ink dark)
-  liquid/              # CSS モジュール
-    main.css
-    color-light.css
-    color-dark.css
-    font.css
-    font-ink.css
-    CodeMirror.css
-    CodeMirror-dark.css
-    custom-ink.css
-    custom-dark.css
-  Deploy/CombineCSS.py # @import を結合して dist に出力
-  deploy/CompressZip.py # dist を liquid.zip にパッケージ
-```
-
-## ソースからビルド
-
-ビルドスクリプトは Windows のパス表記を前提にしています。CombineCSS.py は `src/Deploy`（D 大文字）、CompressZip.py は `src/deploy`（d 小文字）にあります。大文字小文字を区別する環境では正確なフォルダ名を使用してください。
-
-1. Python 3 をインストールします。
-2. `cd src/Deploy` を実行します。
-3. `python CombineCSS.py` を実行し、`@import` を再帰的に展開して `dist/` に出力します。
-4. （任意）`cd ../deploy` と `python CompressZip.py` を実行し、`dist` から `liquid.zip` を作成します。
-
-## CSS モジュール一覧
-
-`src/` 配下のエントリ CSS は `src/liquid/` のモジュールを読み込みます。
-
-- `liquid.css`：light モード（`font.css`、`color-light.css`、`CodeMirror.css`、`main.css`）。
-- `liquid-dark.css`：dark モード（`font.css`、`color-dark.css`、`CodeMirror-dark.css`、`main.css`、`custom-dark.css`）。
-- `liquid-ink.css`：ink モード（`font-ink.css`、`color-light.css`、`CodeMirror.css`、`main.css`、`custom-ink.css`）。
-- `liquid-ink-dark.css`：ink dark モード（`font-ink.css`、`color-dark.css`、`CodeMirror-dark.css`、`main.css`、`custom-ink.css`、`custom-dark.css`）。
-
-主要モジュール：
-
-- `main.css`：共通レイアウト、タイポグラフィ、コンポーネント。
-- `color-light.css` / `color-dark.css`：ライト/ダークの配色変数。
-- `font.css`：標準フォント（Source Han Serif CN + JetBrains Mono）。
-- `font-ink.css`：手書きフォント（Ink Free + FZSJ-SGLDXMHJW）。
-- `CodeMirror.css` / `CodeMirror-dark.css`：コードブロックのスタイル。
-- `custom-ink.css`：Ink モード向けのタイポグラフィ調整。
-- `custom-dark.css`：Dark モード向けの UI 調整。
-
-## カスタマイズ方法
-
-### 1. カスタム CSS を追加（推奨）
-
-Typora のカスタム CSS 機能を使って上書きします。詳しくは <https://support.typora.io/Add-Custom-CSS/> を参照してください。
-
-### 2. コンパイル済みテーマを編集
-
-テーマをインストールした後、テーマフォルダ内の `liquid.css`、`liquid-dark.css`、`liquid-ink.css`、`liquid-ink-dark.css` を直接編集できます。`@font-face` が解決できるように `liquid/` フォントフォルダを CSS の隣に置いてください。
-
-### 3. ソースモジュールを編集
-
-より深く調整する場合は `src/liquid/` のモジュールを編集し、`CombineCSS.py` で再ビルドします。よく触る箇所：
-
-- 色：`color-light.css` と `color-dark.css`
-- フォント：`font.css` と `font-ink.css`
-- コードブロック：`CodeMirror.css` と `CodeMirror-dark.css`
-- Ink/Dark 調整：`custom-ink.css` と `custom-dark.css`
-- レイアウトとタイポグラフィ：`main.css`
-
-## フォントに関する注意
-
-Ink モードでは、ラテン文字に `Inkfree`、中国語に `FZSJ-SGLDXMHJW` を使用します。フォントは同梱され `@font-face` で読み込まれるため、通常はシステムへのインストールは不要です。大文字小文字を区別する環境では `liquid/` のファイル名が CSS の参照（`inkfree.ttf` と `FZSJ-SGLDXMHJW.ttf`）と一致するよう確認し、必要に応じてリネームまたは CSS を調整してください。
+## トラブルシューティング
+- テーマが出ない: 4 つの CSS がテーマフォルダにあるか確認。
+- フォントが効かない: `liquid/` が CSS の隣にあるか確認。
+- 見た目が変わらない: カスタム CSS を一時的に無効化。

--- a/doc/Document_zh.md
+++ b/doc/Document_zh.md
@@ -4,54 +4,17 @@
 
 ## 概述
 
-Liquid 是一个灵感来自 Microsoft Fluent Design 的 Typora 主题。本文档基于当前仓库结构，说明文件布局、构建流程与自定义方式。
+Liquid 是一个受 Microsoft Fluent Design 启发的 Typora 主题。当前仓库采用源码直出结构：主题入口文件与模块都位于 `src/`。
 
-## 文件结构
-
-### 发布包（`liquid.zip`）
-
-发布包由 `dist` 目录生成，包含编译后的 CSS 与字体：
+## 仓库结构
 
 ```text
-liquid.css
-liquid-dark.css
-liquid-ink.css
-liquid-ink-dark.css
-liquid/
-  JetBrainsMono-Bold.woff2
-  JetBrainsMono-Regular.woff2
-  SourceHanSerifCN-Bold.ttf
-  SourceHanSerifCN-Regular.ttf
-  Inkfree.ttf
-  FZSJ-SGLDXMHJW.TTF
-```
-
-### 仓库结构
-
-```text
-Demo.md
-README.md
-README_*.md
-LICENSE
-media/                # 预览图片
-font/                 # 字体源文件
-  JetBrainsMono-2.242/
-  SourceHanSerifCN/
-dist/                 # 编译后的 CSS 与字体资源（发布包内容）
+src/
   liquid.css
   liquid-dark.css
   liquid-ink.css
   liquid-ink-dark.css
   liquid/
-    *.ttf
-    *.woff2
-doc/                  # 文档翻译
-src/
-  liquid.css           # 入口文件（light）
-  liquid-dark.css      # 入口文件（dark）
-  liquid-ink.css       # 入口文件（ink）
-  liquid-ink-dark.css  # 入口文件（ink dark）
-  liquid/              # CSS 模块
     main.css
     color-light.css
     color-dark.css
@@ -61,58 +24,55 @@ src/
     CodeMirror-dark.css
     custom-ink.css
     custom-dark.css
-  Deploy/CombineCSS.py # 合并 @import 输出到 dist
-  deploy/CompressZip.py # 将 dist 打包为 liquid.zip
+    Inkfree.ttf
+    FZSJ-SGLDXMHJW.TTF
+    SourceHanSerifCN-*.ttf
+    JetBrainsMono-*.woff2
+Demo.md
+doc/Document*.md
+README*.md
+media/
+assets/
 ```
 
-## 从源码构建
+## 主题模式
 
-构建脚本使用 Windows 风格路径，建议在 Windows 上执行。CombineCSS.py 位于 `src/Deploy`（大写 D），CompressZip.py 位于 `src/deploy`（小写 d）。在区分大小写的文件系统中请使用准确的目录名。
+- `liquid.css`：浅色模式
+- `liquid-dark.css`：深色模式
+- `liquid-ink.css`：Ink 模式
+- `liquid-ink-dark.css`：Ink 深色模式
 
-1. 安装 Python 3。
-2. 运行 `cd src/Deploy`。
-3. 运行 `python CombineCSS.py`，递归展开 `@import` 并输出到 `dist/`。
-4. （可选）运行 `cd ../deploy` 和 `python CompressZip.py`，从 `dist` 生成 `liquid.zip`。
+## 安装方法
 
-## CSS 模块说明
+1. 在 Typora 中打开 **偏好设置 → 外观 → 打开主题文件夹**。
+2. 将 `src/liquid*.css` 四个文件复制到主题目录。
+3. 将完整 `src/liquid/` 目录复制到与 CSS 同级位置。
+4. 重启 Typora 并选择 Liquid 主题。
 
-`src/` 下的入口 CSS 文件会引入 `src/liquid/` 中的模块：
+## 模块说明
 
-- `liquid.css`：light 模式（引入 `font.css`、`color-light.css`、`CodeMirror.css`、`main.css`）。
-- `liquid-dark.css`：dark 模式（引入 `font.css`、`color-dark.css`、`CodeMirror-dark.css`、`main.css`、`custom-dark.css`）。
-- `liquid-ink.css`：ink 模式（引入 `font-ink.css`、`color-light.css`、`CodeMirror.css`、`main.css`、`custom-ink.css`）。
-- `liquid-ink-dark.css`：ink dark 模式（引入 `font-ink.css`、`color-dark.css`、`CodeMirror-dark.css`、`main.css`、`custom-ink.css`、`custom-dark.css`）。
+入口文件会引入 `src/liquid/` 下模块：
 
-主要模块说明：
-
-- `main.css`：通用布局、排版与组件样式。
-- `color-light.css` / `color-dark.css`：浅色/深色调色板变量。
-- `font.css`：默认字体（Source Han Serif CN + JetBrains Mono）。
-- `font-ink.css`：手写字体（Ink Free + FZSJ-SGLDXMHJW）。
-- `CodeMirror.css` / `CodeMirror-dark.css`：代码块样式。
-- `custom-ink.css`：Ink 模式的排版调整。
-- `custom-dark.css`：Dark 模式的 UI 调整。
-
-## 自定义方式
-
-### 1. 添加自定义 CSS（推荐）
-
-使用 Typora 的自定义 CSS 功能为主题添加覆盖样式，详见 <https://support.typora.io/Add-Custom-CSS/>。
-
-### 2. 编辑编译后的主题文件
-
-安装主题后，直接编辑主题目录中的 `liquid.css`、`liquid-dark.css`、`liquid-ink.css` 或 `liquid-ink-dark.css`。请确保 `liquid/` 字体目录与 CSS 文件同级，以便 `@font-face` 正确加载。
-
-### 3. 编辑源码模块
-
-如需更深度的定制，请修改 `src/liquid/` 中的模块并使用 `CombineCSS.py` 重新构建。常见修改位置：
-
-- 颜色：`color-light.css` 与 `color-dark.css`
-- 字体：`font.css` 与 `font-ink.css`
-- 代码块：`CodeMirror.css` 与 `CodeMirror-dark.css`
-- Ink/Dark 调整：`custom-ink.css` 与 `custom-dark.css`
 - 布局与排版：`main.css`
+- 颜色变量：`color-light.css`、`color-dark.css`
+- 字体栈：`font.css`、`font-ink.css`
+- 代码块样式：`CodeMirror.css`、`CodeMirror-dark.css`
+- 模式修饰：`custom-ink.css`、`custom-dark.css`
+
+## 自定义流程
+
+1. 小改动：直接编辑已安装的 `liquid*.css`。
+2. 大改动：编辑 `src/liquid/` 模块文件。
+3. 建议将个人偏好放在 Typora 自定义 CSS，便于后续升级。
 
 ## 字体说明
 
-Ink 模式依赖 `Inkfree`（拉丁文字）与 `FZSJ-SGLDXMHJW`（中文手写）。字体已通过 `@font-face` 打包，通常不需要系统安装。在区分大小写的文件系统中，请确认 `liquid/` 目录的文件名与 CSS 引用一致（`inkfree.ttf` 与 `FZSJ-SGLDXMHJW.ttf`），必要时重命名文件或修改 CSS。
+- Ink 模式中，`Inkfree` 用于拉丁文字手写风格，`FZSJ-SGLDXMHJW` 用于中文手写风格。
+- 字体通过本地 `liquid/` 目录中的 `@font-face` 加载。
+- 在区分大小写的文件系统上，请确保字体文件名与 CSS 引用大小写完全一致。
+
+## 故障排查
+
+- 主题未显示：检查四个 `liquid*.css` 是否位于主题目录根路径。
+- 字体未生效：检查 `liquid/` 是否与 CSS 同级。
+- 样式没有变化：临时关闭自定义 CSS，排查选择器覆盖冲突。


### PR DESCRIPTION
### Motivation

- Remove legacy build instructions and inaccurate references to a `dist/` pipeline and Windows-only scripts so documentation matches the actual repository layout.  
- Make installation and troubleshooting guidance accurate for users by pointing to the source entry files under `src/`.  
- Keep translations and documentation consistent across all README and `doc/Document_*` variants.

### Description

- Rewrote `README.md` and all translated `README_*.md` files to describe the repository as source-first and to provide updated status, features, installation, customization, and troubleshooting guidance.  
- Rewrote `doc/Document.md` and all translated `doc/Document_*.md` files to present a concise module map, installation instructions using `src/liquid*.css` and the `src/liquid/` folder, and a clear customization workflow.  
- Removed build-from-source as the primary user pathway and removed instructions that directed users to `dist/`, `CombineCSS.py`, or `CompressZip.py` as the recommended workflow, replacing them with actionable guidance to copy the `src/` entry files and modules.  
- Added consistent notes about font bundling and filename/case sensitivity and updated repository layout examples to reflect `src/`, `media/`, and `assets/` locations.

### Testing

- Verified repository layout and presence of theme sources with `find . -maxdepth 3 -type f`, which located `src/liquid*.css` and the `src/liquid/` assets (succeeded).  
- Scanned README and docs with `rg -n "dist/|\bdist\b|CombineCSS|CompressZip|src/Deploy|src/deploy" README*.md doc/Document*.md` to confirm there are no lingering actionable build instructions and that any remaining `dist/` mentions are explicit statements clarifying there is no separate `dist/` output (succeeded).  
- Inspected updated files (`nl` / `sed`) to confirm the new installation, customization, and troubleshooting sections were added across all translations (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69902824db7483298c6df33d9c76ce8b)